### PR TITLE
Add FluentCMS.Configuration.SqlServer project

### DIFF
--- a/FluentCMS.Core.sln
+++ b/FluentCMS.Core.sln
@@ -69,6 +69,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentCMS.Configuration", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentCMS.Configuration.Sqlite", "src\Configuration\FluentCMS.Configuration.Sqlite\FluentCMS.Configuration.Sqlite.csproj", "{849CAD05-BF94-45D6-871D-F39C9D713A29}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentCMS.Configuration.SqlServer", "src\Configuration\FluentCMS.Configuration.SqlServer\FluentCMS.Configuration.SqlServer.csproj", "{352246F6-D829-48D6-9187-41B3A1E40AF1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -355,6 +357,18 @@ Global
 		{849CAD05-BF94-45D6-871D-F39C9D713A29}.Release|x64.Build.0 = Release|Any CPU
 		{849CAD05-BF94-45D6-871D-F39C9D713A29}.Release|x86.ActiveCfg = Release|Any CPU
 		{849CAD05-BF94-45D6-871D-F39C9D713A29}.Release|x86.Build.0 = Release|Any CPU
+		{352246F6-D829-48D6-9187-41B3A1E40AF1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{352246F6-D829-48D6-9187-41B3A1E40AF1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{352246F6-D829-48D6-9187-41B3A1E40AF1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{352246F6-D829-48D6-9187-41B3A1E40AF1}.Debug|x64.Build.0 = Debug|Any CPU
+		{352246F6-D829-48D6-9187-41B3A1E40AF1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{352246F6-D829-48D6-9187-41B3A1E40AF1}.Debug|x86.Build.0 = Debug|Any CPU
+		{352246F6-D829-48D6-9187-41B3A1E40AF1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{352246F6-D829-48D6-9187-41B3A1E40AF1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{352246F6-D829-48D6-9187-41B3A1E40AF1}.Release|x64.ActiveCfg = Release|Any CPU
+		{352246F6-D829-48D6-9187-41B3A1E40AF1}.Release|x64.Build.0 = Release|Any CPU
+		{352246F6-D829-48D6-9187-41B3A1E40AF1}.Release|x86.ActiveCfg = Release|Any CPU
+		{352246F6-D829-48D6-9187-41B3A1E40AF1}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -384,6 +398,7 @@ Global
 		{773F77C5-BD72-4F4D-ABDF-4CDBEDC71DAA} = {12288030-F57A-4F6C-A7F4-CD6126134C3E}
 		{F85B4D0A-C516-4869-A67A-515D71A84D50} = {54FCAC6C-FA76-4E82-8700-24492EAAEDBB}
 		{849CAD05-BF94-45D6-871D-F39C9D713A29} = {54FCAC6C-FA76-4E82-8700-24492EAAEDBB}
+		{352246F6-D829-48D6-9187-41B3A1E40AF1} = {54FCAC6C-FA76-4E82-8700-24492EAAEDBB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4A20D9D5-B268-4753-8057-813B6394829F}

--- a/src/Configuration/FluentCMS.Configuration.SqlServer/FluentCMS.Configuration.SqlServer.csproj
+++ b/src/Configuration/FluentCMS.Configuration.SqlServer/FluentCMS.Configuration.SqlServer.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FluentCMS.Configuration\FluentCMS.Configuration.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Configuration/FluentCMS.Configuration.SqlServer/SqlServerExtensions.cs
+++ b/src/Configuration/FluentCMS.Configuration.SqlServer/SqlServerExtensions.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace FluentCMS.Configuration.SqlServer;
+
+public static class SqlServerExtensions
+{
+    public static void AddSqlServerOptions(this IHostApplicationBuilder builder, string connectionString, long? reloadInterval = null)
+    {
+        DbConfigurationSource configSource = default!;
+
+        builder.Configuration.Add<DbConfigurationSource>(source =>
+        {
+            configSource = source;
+
+            source.Repository = new SqlServerOptionsRepository(connectionString);
+            if (reloadInterval.HasValue)
+                source.ReloadInterval = TimeSpan.FromSeconds(reloadInterval.Value);
+        });
+
+        builder.Services.AddSingleton(sp => configSource);
+    }
+}

--- a/src/Configuration/FluentCMS.Configuration.SqlServer/SqlServerOptionsRepository.cs
+++ b/src/Configuration/FluentCMS.Configuration.SqlServer/SqlServerOptionsRepository.cs
@@ -1,0 +1,153 @@
+﻿using Microsoft.Data.SqlClient;
+using System.Data;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace FluentCMS.Configuration.SqlServer;
+
+internal class SqlServerOptionsRepository(string connectionString) : IOptionsRepository
+{
+    // Use NVARCHAR to store text; 450 keeps PK within SQL Server's index key size limit (900 bytes).
+    private const string CreateSql = @"
+            IF OBJECT_ID(N'dbo.Options', N'U') IS NULL
+            BEGIN
+                CREATE TABLE dbo.Options
+                (
+                    Section NVARCHAR(450) NOT NULL PRIMARY KEY,
+                    Value   NVARCHAR(MAX) NOT NULL
+                );
+            END
+            ";
+
+    private const string SelectAllSql = "SELECT Section, Value FROM dbo.Options;";
+
+    // Upsert implemented as: UPDATE first; if no rows affected, INSERT.
+    private const string UpdateSql = @"
+            UPDATE dbo.Options
+            SET Value = @value
+            WHERE Section = @section;
+            ";
+
+    private const string InsertSql = @"
+            INSERT INTO dbo.Options (Section, Value)
+            VALUES (@section, @value);
+            ";
+
+    public async Task EnsureCreated(CancellationToken cancellationToken = default)
+    {
+        await using var conn = new SqlConnection(connectionString);
+        await conn.OpenAsync(cancellationToken);
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = CreateSql;
+        await cmd.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    public async Task<Dictionary<string, string?>> GetAllSections(CancellationToken cancellationToken = default)
+    {
+        var data = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+
+        await using var conn = new SqlConnection(connectionString);
+        await conn.OpenAsync(cancellationToken);
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = SelectAllSql;
+
+        await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            var section = reader.GetString(0);
+            var json = reader.GetString(1);
+
+            try
+            {
+                var node = JsonNode.Parse(json);
+                if (node is JsonObject obj)
+                {
+                    FlattenJson(data, section, obj);
+                }
+            }
+            catch
+            {
+                // Ignore malformed rows
+            }
+        }
+
+        return data;
+    }
+
+    public async Task<int> Upsert(OptionRegistration registration, CancellationToken cancellationToken = default)
+    {
+        await using var conn = new SqlConnection(connectionString);
+        await conn.OpenAsync(cancellationToken);
+
+        // We’ll try UPDATE first; if it didn’t touch anything, do INSERT.
+        await using var updateCmd = conn.CreateCommand();
+        updateCmd.CommandText = UpdateSql;
+        AddParameters(updateCmd, registration);
+
+        var affected = await updateCmd.ExecuteNonQueryAsync(cancellationToken);
+        if (affected > 0)
+            return affected;
+
+        await using var insertCmd = conn.CreateCommand();
+        insertCmd.CommandText = InsertSql;
+        AddParameters(insertCmd, registration);
+
+        try
+        {
+            affected = await insertCmd.ExecuteNonQueryAsync(cancellationToken);
+            return affected;
+        }
+        catch (SqlException ex) when (ex.Number == 2627 || ex.Number == 2601) // PK/Unique violation
+        {
+            // Race: someone inserted between our UPDATE and INSERT. Treat as success (0 or 1).
+            return 0;
+        }
+    }
+
+    private static void AddParameters(SqlCommand cmd, OptionRegistration reg)
+    {
+        // Explicit sizes/types to avoid AddWithValue pitfalls.
+        var pSection = new SqlParameter("@section", SqlDbType.NVarChar, 450) { Value = reg.Section };
+        var pValue = new SqlParameter("@value", SqlDbType.NVarChar, -1) { Value = reg.DefaultValue ?? (object)DBNull.Value };
+
+        cmd.Parameters.Add(pSection);
+        cmd.Parameters.Add(pValue);
+    }
+
+    private static void FlattenJson(Dictionary<string, string?> data, string prefix, JsonObject obj)
+    {
+        foreach (var kvp in obj)
+        {
+            var key = string.IsNullOrEmpty(prefix) ? kvp.Key : $"{prefix}:{kvp.Key}";
+            switch (kvp.Value)
+            {
+                case JsonObject childObj:
+                    FlattenJson(data, key, childObj);
+                    break;
+
+                case JsonArray arr:
+                    for (int i = 0; i < arr.Count; i++)
+                    {
+                        var item = arr[i];
+                        if (item is JsonObject itemObj)
+                        {
+                            FlattenJson(data, $"{key}:{i}", itemObj);
+                        }
+                        else
+                        {
+                            data[$"{key}:{i}"] = item?.ToJsonString();
+                        }
+                    }
+                    break;
+
+                default:
+                    data[key] = kvp.Value?.GetValueKind() is JsonValueKind.String
+                        ? kvp.Value!.ToString()
+                        : kvp.Value?.ToJsonString();
+                    break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces a new project named "FluentCMS.Configuration.SqlServer" targeting .NET 9.0, which includes a package reference to `Microsoft.Data.SqlClient` for SQL Server interactions. The solution configuration has been updated to support Debug and Release builds for the new project across multiple platforms.

Additionally, new classes and methods have been added in `SqlServerExtensions.cs` and `SqlServerOptionsRepository.cs`. The `SqlServerExtensions` class provides an extension method for adding SQL Server options to the application builder, while the `SqlServerOptionsRepository` class implements the `IOptionsRepository` interface, managing the creation of a database table for options and supporting retrieval and upsert operations.