### PR TITLE
Enhance provider module and catalog cache robustness

### DIFF
--- a/src/Providers/Core/FluentCMS.Providers.Repositories.EntityFramework/ProviderDbContext.cs
+++ b/src/Providers/Core/FluentCMS.Providers.Repositories.EntityFramework/ProviderDbContext.cs
@@ -19,11 +19,17 @@ public class ProviderDbContext(DbContextOptions<ProviderDbContext> options) : Db
         // Configure Provider entity
         modelBuilder.Entity<Provider>(entity =>
         {
+            // Primary key
             entity.HasKey(p => p.Id);
 
+            // Required properties with length constraints
             entity.Property(p => p.Name)
                 .IsRequired()
                 .HasMaxLength(100);
+
+            entity.Property(p => p.DisplayName)
+                .IsRequired()
+                .HasMaxLength(400);
 
             entity.Property(p => p.Area)
                 .IsRequired()
@@ -33,9 +39,14 @@ public class ProviderDbContext(DbContextOptions<ProviderDbContext> options) : Db
                 .IsRequired()
                 .HasMaxLength(200);
 
+            // Optional properties
             entity.Property(p => p.Options)
-                .HasMaxLength(4000);
+                .HasMaxLength(4000)
+                .IsUnicode(true); // Support JSON with Unicode characters
 
+            entity.Property(p => p.IsActive)
+                .IsRequired()
+                .HasDefaultValue(false);
         });
     }
 }

--- a/src/Providers/Core/FluentCMS.Providers/ProviderFeatureBuilderExtensions.cs
+++ b/src/Providers/Core/FluentCMS.Providers/ProviderFeatureBuilderExtensions.cs
@@ -43,7 +43,7 @@ public static class ProviderFeatureBuilderExtensions
             }
             catch (Exception)
             {
-                if (opts.IgnoreExceptions)
+                if (!opts.IgnoreExceptions)
                     throw;
             }
         }
@@ -53,48 +53,88 @@ public static class ProviderFeatureBuilderExtensions
         {
             services.AddTransient(interfaceType, serviceProvider =>
             {
-                var providerManager = serviceProvider.GetRequiredService<IProviderManager>();
-                var catalog = providerManager.GetActiveByArea(area).GetAwaiter().GetResult() ??
-                    throw new InvalidOperationException($"No active provider found for area '{area}'.");
+                var providerCatalogCache = serviceProvider.GetRequiredService<ProviderCatalogCache>();
+                
+                // Synchronous access to avoid deadlock issues
+                var catalog = providerCatalogCache.GetActiveCatalog(area) ??
+                    throw new InvalidOperationException($"No active provider found for area '{area}'. Ensure providers are properly initialized.");
 
-                // Check if the provider's type implements the requested interface
+                // Validate provider implements the requested interface
                 if (!interfaceType.IsAssignableFrom(catalog.Module.ProviderType))
-                    throw new InvalidOperationException($"The active provider '{catalog.Name}' for area '{area}' does not implement the interface '{interfaceType.FullName}'.");
-
-                var providerType = catalog.Module.ProviderType;
-
-                // Check if the provider type has more than one constructor, then raise exception
-                var constructors = providerType.GetConstructors();
-                if (constructors.Length == 0)
-                    throw new InvalidOperationException($"The provider type '{providerType.FullName}' has no public constructors.");
-
-                if (constructors.Length > 1)
-                    throw new InvalidOperationException($"The provider type '{providerType.FullName}' has more than one constructor. Only one constructor is allowed.");
-
-                // Prepare arguments for the constructor
-                var constructor = constructors[0];
-                var argsList = new List<object>();
-
-                if (catalog.Options != null)
                 {
-                    foreach (var parameter in constructor.GetParameters())
-                    {
-                        // Adding the options instance
-                        if (parameter.ParameterType == catalog.Module.OptionsType)
-                            argsList.Add(catalog.Options);
-
-                        if (parameter.ParameterType.IsGenericType && parameter.ParameterType.GetGenericTypeDefinition() == typeof(IOptions<>) && parameter.ParameterType.GetGenericArguments()[0] == catalog.Module.OptionsType)
-                        {
-                            var optionsCreate = typeof(Options).GetMethods(BindingFlags.Public | BindingFlags.Static).First(m => m.Name == nameof(Options.Create) && m.IsGenericMethodDefinition);
-                            var createGeneric = optionsCreate.MakeGenericMethod(catalog.Module.OptionsType);
-                            var ioptionsInstance = createGeneric.Invoke(null, [catalog.Options]);
-                            argsList.Add(ioptionsInstance!);
-                        }
-                    }
+                    throw new InvalidOperationException(
+                        $"The active provider '{catalog.Name}' for area '{area}' does not implement the interface '{interfaceType.FullName}'. " +
+                        $"Provider type: '{catalog.Module.ProviderType.FullName}'");
                 }
 
-                return ActivatorUtilities.CreateInstance(serviceProvider, catalog.Module.ProviderType, [.. argsList]);
+                return CreateProviderInstance(serviceProvider, catalog);
             });
         }
+    }
+
+    private static object CreateProviderInstance(IServiceProvider serviceProvider, ProviderCatalog catalog)
+    {
+        var providerType = catalog.Module.ProviderType;
+
+        // Validate constructor requirements
+        var constructors = providerType.GetConstructors();
+        if (constructors.Length == 0)
+        {
+            throw new InvalidOperationException(
+                $"The provider type '{providerType.FullName}' has no public constructors.");
+        }
+
+        if (constructors.Length > 1)
+        {
+            throw new InvalidOperationException(
+                $"The provider type '{providerType.FullName}' has multiple constructors. " +
+                $"Only providers with a single constructor are supported.");
+        }
+
+        // Build constructor arguments
+        var constructor = constructors[0];
+        var constructorArgs = BuildConstructorArguments(constructor, catalog);
+
+        try
+        {
+            return ActivatorUtilities.CreateInstance(serviceProvider, providerType, constructorArgs);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException(
+                $"Failed to create instance of provider '{providerType.FullName}' for area '{catalog.Module.Area}'. " +
+                $"Provider: '{catalog.Name}'", ex);
+        }
+    }
+
+    private static object[] BuildConstructorArguments(ConstructorInfo constructor, ProviderCatalog catalog)
+    {
+        if (catalog.Options == null || catalog.Module.OptionsType == null)
+        {
+            return [];
+        }
+
+        var argsList = new List<object>();
+        foreach (var parameter in constructor.GetParameters())
+        {
+            // Direct options type injection
+            if (parameter.ParameterType == catalog.Module.OptionsType)
+            {
+                argsList.Add(catalog.Options);
+                continue;
+            }
+
+            // IOptions<T> wrapper injection
+            if (parameter.ParameterType.IsGenericType && 
+                parameter.ParameterType.GetGenericTypeDefinition() == typeof(IOptions<>) && 
+                parameter.ParameterType.GetGenericArguments()[0] == catalog.Module.OptionsType)
+            {
+                var optionsWrapperType = typeof(OptionsWrapper<>).MakeGenericType(catalog.Module.OptionsType);
+                var optionsWrapper = Activator.CreateInstance(optionsWrapperType, catalog.Options);
+                argsList.Add(optionsWrapper!);
+            }
+        }
+
+        return [.. argsList];
     }
 }

--- a/src/Providers/Core/FluentCMS.Providers/ProviderModuleCatalogCache.cs
+++ b/src/Providers/Core/FluentCMS.Providers/ProviderModuleCatalogCache.cs
@@ -1,42 +1,150 @@
 ﻿using FluentCMS.Providers.Abstractions;
+using System.Collections.Concurrent;
 
 namespace FluentCMS.Providers;
 
 internal sealed class ProviderModuleCatalogCache
 {
     // Area -> (TypeName -> IProviderModule)
-    private readonly Dictionary<string, Dictionary<string, IProviderModule>> registeredModules = [];
+    private readonly ConcurrentDictionary<string, Dictionary<string, IProviderModule>> registeredModules = new();
 
-    // Area -> InterfaceType)
-    private readonly Dictionary<string, Type> registeredInterfaces = [];
+    // Area -> InterfaceType
+    private readonly ConcurrentDictionary<string, Type> registeredInterfaces = new();
+
+    // Cache for faster module lookups
+    private readonly ConcurrentDictionary<string, IProviderModule> modulesByFullKey = new();
 
     public ProviderModuleCatalogCache(IEnumerable<IProviderModule> modules)
     {
-        foreach (var module in modules)
+        ArgumentNullException.ThrowIfNull(modules);
+
+        var moduleList = modules.ToList();
+        ValidateModules(moduleList);
+
+        foreach (var module in moduleList)
         {
-            if (!registeredInterfaces.TryGetValue(module.Area, out Type? valueType))
-            {
-                registeredInterfaces[module.Area] = module.InterfaceType;
-            }
-            else if (valueType != module.InterfaceType)
-            {
-                throw new InvalidOperationException($"Multiple interface types registered for area '{module.Area}'.");
-            }
-
-            if (!registeredModules.TryGetValue(module.Area, out Dictionary<string, IProviderModule>? value))
-            {
-                value = new Dictionary<string, IProviderModule>(StringComparer.OrdinalIgnoreCase);
-                registeredModules[module.Area] = value;
-            }
-            var moduleType = module.GetType().FullName ??
-                throw new InvalidOperationException("Provider type must have a full name.");
-
-            value[moduleType] = module;
+            RegisterModule(module);
         }
     }
+
+    private void ValidateModules(IEnumerable<IProviderModule> modules)
+    {
+        var duplicateModules = modules
+            .GroupBy(m => new { m.Area, ModuleType = m.GetType().FullName })
+            .Where(g => g.Count() > 1)
+            .Select(g => g.Key)
+            .ToList();
+
+        if (duplicateModules.Any())
+        {
+            var duplicateList = string.Join(", ", duplicateModules.Select(d => $"{d.Area}:{d.ModuleType}"));
+            throw new InvalidOperationException(
+                $"Duplicate provider modules found: {duplicateList}");
+        }
+
+        // Validate that all modules have valid properties
+        foreach (var module in modules)
+        {
+            ValidateModule(module);
+        }
+    }
+
+    private static void ValidateModule(IProviderModule module)
+    {
+        ArgumentNullException.ThrowIfNull(module);
+
+        if (string.IsNullOrWhiteSpace(module.Area))
+        {
+            throw new InvalidOperationException(
+                $"Provider module '{module.GetType().FullName}' has invalid area. Area cannot be null or empty.");
+        }
+
+        if (string.IsNullOrWhiteSpace(module.DisplayName))
+        {
+            throw new InvalidOperationException(
+                $"Provider module '{module.GetType().FullName}' has invalid display name. Display name cannot be null or empty.");
+        }
+
+        var moduleTypeName = module.GetType().FullName;
+        if (string.IsNullOrEmpty(moduleTypeName))
+        {
+            throw new InvalidOperationException(
+                $"Provider module type must have a full name. Module: {module.GetType()}");
+        }
+
+        // Validate that the provider type actually implements IProvider
+        if (!typeof(IProvider).IsAssignableFrom(module.ProviderType))
+        {
+            throw new InvalidOperationException(
+                $"Provider module '{moduleTypeName}' specifies provider type '{module.ProviderType.FullName}' " +
+                $"which does not implement IProvider.");
+        }
+
+        // Validate that the interface type is compatible with the provider type
+        if (!module.InterfaceType.IsAssignableFrom(module.ProviderType))
+        {
+            throw new InvalidOperationException(
+                $"Provider module '{moduleTypeName}' specifies interface type '{module.InterfaceType.FullName}' " +
+                $"which is not implemented by provider type '{module.ProviderType.FullName}'.");
+        }
+
+        // Validate options type if specified
+        if (module.OptionsType != null)
+        {
+            try
+            {
+                // Try to create an instance to validate it has a parameterless constructor
+                Activator.CreateInstance(module.OptionsType);
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException(
+                    $"Provider module '{moduleTypeName}' specifies options type '{module.OptionsType.FullName}' " +
+                    $"which cannot be instantiated. Ensure it has a public parameterless constructor.", ex);
+            }
+        }
+    }
+
+    private void RegisterModule(IProviderModule module)
+    {
+        var moduleTypeName = module.GetType().FullName!;
+
+        // Register interface type for the area
+        registeredInterfaces.AddOrUpdate(module.Area,
+            module.InterfaceType,
+            (area, existingType) =>
+            {
+                if (existingType != module.InterfaceType)
+                {
+                    throw new InvalidOperationException(
+                        $"Multiple interface types registered for area '{area}'. " +
+                        $"Existing: '{existingType.FullName}', New: '{module.InterfaceType.FullName}'");
+                }
+                return existingType;
+            });
+
+        // Register module by area and type name
+        registeredModules.AddOrUpdate(module.Area,
+            new Dictionary<string, IProviderModule>(StringComparer.OrdinalIgnoreCase) { [moduleTypeName] = module },
+            (area, existingModules) =>
+            {
+                if (existingModules.ContainsKey(moduleTypeName))
+                {
+                    throw new InvalidOperationException(
+                        $"Provider module '{moduleTypeName}' is already registered for area '{area}'.");
+                }
+                existingModules[moduleTypeName] = module;
+                return existingModules;
+            });
+
+        // Add to cache for faster lookups
+        var fullKey = $"{module.Area}:{moduleTypeName}";
+        modulesByFullKey[fullKey] = module;
+    }
+
     public IEnumerable<IProviderModule> GetRegisteredModules()
     {
-        return registeredModules.Values.SelectMany(dict => dict.Values);
+        return modulesByFullKey.Values;
     }
 
     public IReadOnlyDictionary<string, Type> GetRegisteredInterfaceTypes()
@@ -46,12 +154,30 @@ internal sealed class ProviderModuleCatalogCache
 
     public IProviderModule? GetRegisteredModule(string area, string typeName)
     {
-        if (registeredModules.TryGetValue(area, out var areaModules) &&
-            areaModules.TryGetValue(typeName, out var module))
-        {
-            return module;
-        }
-        return null;
+        ArgumentException.ThrowIfNullOrWhiteSpace(area);
+        ArgumentException.ThrowIfNullOrWhiteSpace(typeName);
+
+        var fullKey = $"{area}:{typeName}";
+        return modulesByFullKey.TryGetValue(fullKey, out var module) ? module : null;
     }
 
+    public IEnumerable<IProviderModule> GetModulesByArea(string area)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(area);
+
+        return registeredModules.TryGetValue(area, out var areaModules) 
+            ? areaModules.Values 
+            : [];
+    }
+
+    public bool HasModulesInArea(string area)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(area);
+        return registeredModules.ContainsKey(area);
+    }
+
+    public IEnumerable<string> GetRegisteredAreas()
+    {
+        return registeredModules.Keys;
+    }
 }


### PR DESCRIPTION
Refactored ProviderCatalogCache and ProviderModuleCatalogCache for improved thread safety, immutability, and validation. ProviderCatalogCache now uses ImmutableList for area-based catalogs, enforces single active provider per area, and provides thread-safe operations. ProviderModuleCatalogCache now validates modules for duplicates, interface compatibility, and options instantiation, and uses concurrent collections for safe access. ProviderFeatureBuilderExtensions improved for stricter error handling and clearer provider instantiation logic. ProviderDbContext updated with additional property constraints and defaults.